### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/Collection.js
+++ b/Collection.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var upperCamelCase = require('uppercamelcase');
 var async = require('async');
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 var couchbase = require('couchbase');
 var compareOpts = require('./comparisonOperation.json');
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var _         = require('lodash');
 var Connection   = require('./Connection');
 var Collection   = require('./Collection');
 var util = require('util');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var Errors = require('waterline-errors').adapter;
 var couchbase = require('couchbase');
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "couchnode": "^4.3.4",
     "deepmerge": "^0.2.10",
     "lodash": "^4.13.1",
-    "node-uuid": "^1.4.7",
     "ottoman": "git+https://github.com/lan-nguyen91/node-ottoman.git",
     "uppercamelcase": "^1.1.0",
+    "uuid": "^3.0.0",
     "waterline-errors": "^0.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.